### PR TITLE
Feat: header

### DIFF
--- a/public/sprite.svg
+++ b/public/sprite.svg
@@ -2,6 +2,77 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
+    <symbol
+      id="icon-search"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg">
+      <g clip-path="url(#clip0_348_1061)">
+        <path
+          d="M21 21L16.6569 16.6569M16.6569 16.6569C18.1046 15.2091 19 13.2091 19 11C19 6.58172 15.4183 3 11 3C6.58172 3 3 6.58172 3 11C3 15.4183 6.58172 19 11 19C13.2091 19 15.2091 18.1046 16.6569 16.6569Z"
+          stroke="#313131"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round" />
+      </g>
+      <defs>
+        <clipPath id="clip0_348_1061">
+          <rect
+            width="24"
+            height="24"
+            fill="white" />
+        </clipPath>
+      </defs>
+    </symbol>
+    <symbol
+      id="icon-notification"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg">
+      <g clip-path="url(#clip0_348_1062)">
+        <path
+          d="M6 19V10C6 6.68629 8.68629 4 12 4V4C15.3137 4 18 6.68629 18 10V19M6 19H18M6 19H4M18 19H20"
+          stroke="#313131"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round" />
+        <path
+          d="M11 22L13 22"
+          stroke="#313131"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round" />
+        <circle
+          cx="12"
+          cy="3"
+          r="1"
+          stroke="#313131"
+          stroke-width="1.5" />
+      </g>
+      <defs>
+        <clipPath id="clip0_348_1062">
+          <rect
+            width="24"
+            height="24"
+            fill="white" />
+        </clipPath>
+      </defs>
+    </symbol>
+    <symbol id='icon-close' width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_107_638)">
+<path d="M7 7L17 17M7 17L17 7" stroke="#313131" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_107_638">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</symbol>
+
   </defs>
 </svg>
 

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,5 +1,38 @@
-const Header = () => {
-  return <></>;
+import { styled } from 'styled-system/jsx';
+import { Between, Flex, Align } from '@/styles/layout';
+import { cx } from 'styled-system/css';
+import { HeaderType } from '@/types/types';
+
+const Header = ({ logo, text, icons }: HeaderType) => {
+  return (
+    <Container className={cx(Flex, Between, Align)}>
+      <Left>{logo}</Left>
+      <Center>{text}</Center>
+      <Right className={Flex}>{icons}</Right>
+    </Container>
+  );
 };
 
-export default Header
+const Container = styled.header`
+  position: sticky;
+  top: 0;
+  margin: 0 20px;
+  height: 46px;
+`;
+
+const Nav = styled.nav`
+  display: inline-block;
+`;
+
+const Left = styled(Nav)``;
+
+const Center = styled.h2`
+  font-size: var(--font-sizes-lg);
+  font-weight: 500;
+`;
+
+const Right = styled.span`
+  gap: 15px;
+`;
+
+export default Header;

--- a/src/components/common/HeaderCloseIcon.tsx
+++ b/src/components/common/HeaderCloseIcon.tsx
@@ -1,0 +1,17 @@
+import Icon from '@/components/common/Icon';
+import { ICON_CLOSE } from '@/constants/icons';
+import { useClose } from '@/hooks/useClose';
+
+const HeaderCloseIcon = () => {
+  const { handleTouch } = useClose();
+
+  return (
+    <>
+      <Icon
+        {...ICON_CLOSE}
+        onTouchEnd={handleTouch}></Icon>
+    </>
+  );
+};
+
+export default HeaderCloseIcon;

--- a/src/components/common/HeaderIcons.tsx
+++ b/src/components/common/HeaderIcons.tsx
@@ -1,0 +1,23 @@
+import Icon from '@/components/common/Icon';
+import { ICON_NOTIFICATION, ICON_SEARCH } from '@/constants/icons';
+import { useNavigateTo } from '@/hooks/useNavigateTo';
+
+const HeaderIcons = () => {
+  const toSearch = useNavigateTo('/search');
+  const toNotification = useNavigateTo('/notification');
+
+  return (
+    <>
+      <Icon
+        {...ICON_SEARCH}
+        onTouchEnd={toSearch}
+      />
+      <Icon
+        {...ICON_NOTIFICATION}
+        onTouchEnd={toNotification}
+      />
+    </>
+  );
+};
+
+export default HeaderIcons;

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -1,6 +1,17 @@
-const Icon = ({ id, ...props }: { id: string }) => {
+const Icon = ({
+  id,
+  size,
+  onTouchEnd
+}: {
+  id: string;
+  size: string;
+  onTouchEnd?: () => void;
+}) => {
   return (
-    <svg {...props}>
+    <svg
+      width={size}
+      height={size}
+      onTouchEnd={onTouchEnd}>
       <use href={`/sprite.svg#${id}`} />
     </svg>
   );

--- a/src/constants/icons.ts
+++ b/src/constants/icons.ts
@@ -1,0 +1,12 @@
+export const ICON_SEARCH = {
+  id: 'icon-search',
+  size: '24'
+};
+export const ICON_NOTIFICATION = {
+  id: 'icon-notification',
+  size: '24'
+};
+export const ICON_CLOSE = {
+  id: 'icon-close',
+  size: '24'
+};

--- a/src/hooks/useClose.tsx
+++ b/src/hooks/useClose.tsx
@@ -1,0 +1,20 @@
+import { useNavigateTo } from '@/hooks/useNavigateTo';
+
+export const useClose = () => {
+  const location = window.location.href;
+  const routeMap = {
+    post: '/posts',
+    register: '/home',
+    // PROFILE => 유저 본인으로 이동할 수 있게 수정
+    mypage: '/profile',
+    default: '/'
+  };
+
+  const handleTouch = () => {
+    const routesMap = Object.keys(routeMap);
+    const targetRoute =
+      routesMap.find(key => location.includes(key)) || routeMap['default'];
+    useNavigateTo(targetRoute);
+  };
+  return { handleTouch };
+};

--- a/src/hooks/useNavigateTo.tsx
+++ b/src/hooks/useNavigateTo.tsx
@@ -1,0 +1,10 @@
+import { useNavigate } from 'react-router-dom';
+
+export const useNavigateTo = (to: string) => {
+  const navigate = useNavigate();
+  const toWhere = () => {
+    navigate(to);
+  };
+
+  return toWhere;
+};

--- a/src/pages/Layout.tsx
+++ b/src/pages/Layout.tsx
@@ -15,7 +15,10 @@ const Layout = () => {
 };
 
 const Container = styled.main`
+  position: relative;
   max-width: 500px;
+  min-width: 375px;
+  height: 100%;
 `;
 
 export default Layout;

--- a/src/pages/Router.tsx
+++ b/src/pages/Router.tsx
@@ -6,15 +6,26 @@ import {
 } from 'react-router-dom';
 import Layout from '@/pages/Layout';
 import { ROUTES } from '@/constants/routes';
+import { LazyRouteType } from '@/types/types';
 
 const LazyRoutes = ROUTES.map(route => {
-  const ifHome = route === 'Home';
+  const routeConfig: { [key: string]: LazyRouteType } = {
+    Home: { index: true, path: '' },
+    Start: { index: false, path: 'start/:id' },
+    Post: { index: false, path: 'post/:postid' }
+  };
+
+  const { index, path } = routeConfig[route] || {
+    index: false,
+    path: route.toLowerCase()
+  };
   const LazyComponent = React.lazy(() => import(`./Page-${route}.tsx`));
+
   return (
     <Route
       key={route}
-      index={ifHome}
-      path={ifHome ? '' : route.toLocaleLowerCase()}
+      index={index}
+      path={path}
       element={<LazyComponent />}
     />
   );

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,0 +1,10 @@
+export interface LazyRouteType {
+  index: boolean;
+  path: string;
+}
+
+export interface HeaderType {
+  logo?: React.ReactNode;
+  text?: string;
+  icons?: React.ReactNode;
+}


### PR DESCRIPTION
## ☕ PR 타입

- [x] 기능 추가


## ☕ 작업 내용
![Screenshot 2023-12-12 9 57 28 AM](https://github.com/7-7-2/DDOCKER/assets/115582699/decfa089-5cf0-42f0-9b8a-05294a98fd93)
![Screenshot 2023-12-12 9 58 02 AM](https://github.com/7-7-2/DDOCKER/assets/115582699/c51bd988-e42a-41c5-a454-d1be1b645933)

- props로 left, center, right를 받습니다. 우측 검색/알림 아이콘의 경우 HeaderIcons를 props로 전달하시면 되고 X 아이콘의 경우 HeaderCloseICon을 props로 전달하시면 됩니다. HeaderCloseICon의 경우 페이지별로 뒤로 가기가 아닌 해당 페이지의 루트 라우트 경로로 이동하는 유저플로우라서 useClose에서 경로를 관리하는 훅을 생성했습니다.  
<!--<img width="300" alt="image" src="">-->

## ☕ 관련 issue
close #9 