### PR TITLE
Refactor:  Firestore profileUrl Fetch & 재사용 컴포넌트 분리

### DIFF
--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -21,9 +21,11 @@ export const setStorageImg = async (path: string, file: File) => {
 // storage 에 저장된 이미지를 다운로드 하는 함수
 export const getStorageImg = async (path: string): Promise<string | void> => {
   const storageRef = ref(storage, path);
-  return await getDownloadURL(storageRef).catch(error =>
+  try {
+    return await getDownloadURL(storageRef);
+  } catch (error) {
     console.log('다운로드 실패:', error)
-  );
+  };
 };
 
 // 생성된 문서에 다운로드 받은 이미지를 업데이트(수정, 추가) 하는 함수

--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -1,11 +1,61 @@
-import { ref, uploadBytes } from 'firebase/storage';
-import { storage } from '@/firebase.config';
+import { doc, getFirestore, updateDoc, DocumentReference } from 'firebase/firestore'
+import { ref, uploadBytes, getStorage, getDownloadURL } from 'firebase/storage';
+import { app } from '@/firebase.config';
+import { CachedData, Collections } from '@/types/types';
+import useGetCacheData from '@/hooks/useGetCacheData';
 
-export const useStorage = () => {
-  const uploadFile = async (path: string, file: File) => {
+export const storage = getStorage(app);
+
+// userId 를 가져오는 함수
+const getUserId = async () => {
+    const userId: CachedData = await useGetCacheData('user', '/userId');
+    return userId.cacheData;
+  };
+
+// 생성된 문서를 가져오는 함수
+export const getUserDocRef = async (): Promise<DocumentReference> => {
+  const userId = (await getUserId()) as string;
+  return doc(getFirestore(), Collections.USERS, userId);
+};
+
+// // profileUrl 을 실시간으로 업데이트 하는 함수
+// export const setProfileImg = async (profileUrl: UserTypes) => {
+//     const userDocRef = await getUserDocRef();
+    
+//     const updateDB = onSnapshot(userDocRef, (snapshot: DocumentSnapshot) => {
+//         const userData = snapshot.data();
+//         const selectedDoc = userData?.user?.profileUrl as string | undefined;
+//         if (selectedDoc) {
+//             profileUrl.profileUrl = selectedDoc
+//           }
+//   }) 
+//   return {updateDB}
+// } 
+
+// storage 에 이미지를 업로드 하는 함수
+export const setStorageImg = async (path: string, file: File) => {
     const storageRef = ref(storage, path);
     await uploadBytes(storageRef, file);
   };
 
-  return { uploadFile };
+// storage 에 저장된 이미지를 다운로드 하는 함수
+export const getStorageImg = async (path: string): Promise<string | null> => {
+    const storageRef = ref(storage, path);
+  try {
+    return await getDownloadURL(storageRef);
+  } catch (error) {
+    console.error("다운로드 실패:", error);
+    return null;
+  }
 };
+
+// 생성된 문서에 다운로드 받은 이미지를 업데이트(수정, 추가) 하는 함수
+export const setProfileImg = async (getUserDocRef: DocumentReference, filePath: string): Promise<void> => {
+    const downloadURL = await getStorageImg(filePath)
+    if (downloadURL) {
+        await updateDoc(getUserDocRef, {
+            'user.profileUrl': downloadURL
+        })    
+    }
+    
+}

--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -1,36 +1,16 @@
 import { doc, getFirestore, updateDoc, DocumentReference } from 'firebase/firestore'
 import { ref, uploadBytes, getStorage, getDownloadURL } from 'firebase/storage';
+import { getUserId } from '@/api/user';
 import { app } from '@/firebase.config';
-import { CachedData, Collections } from '@/types/types';
-import useGetCacheData from '@/hooks/useGetCacheData';
+import { Collections } from '@/types/types';
 
 export const storage = getStorage(app);
-
-// userId 를 가져오는 함수
-const getUserId = async () => {
-    const userId: CachedData = await useGetCacheData('user', '/userId');
-    return userId.cacheData;
-  };
 
 // 생성된 문서를 가져오는 함수
 export const getUserDocRef = async (): Promise<DocumentReference> => {
   const userId = (await getUserId()) as string;
   return doc(getFirestore(), Collections.USERS, userId);
 };
-
-// // profileUrl 을 실시간으로 업데이트 하는 함수
-// export const setProfileImg = async (profileUrl: UserTypes) => {
-//     const userDocRef = await getUserDocRef();
-    
-//     const updateDB = onSnapshot(userDocRef, (snapshot: DocumentSnapshot) => {
-//         const userData = snapshot.data();
-//         const selectedDoc = userData?.user?.profileUrl as string | undefined;
-//         if (selectedDoc) {
-//             profileUrl.profileUrl = selectedDoc
-//           }
-//   }) 
-//   return {updateDB}
-// } 
 
 // storage 에 이미지를 업로드 하는 함수
 export const setStorageImg = async (path: string, file: File) => {
@@ -39,23 +19,17 @@ export const setStorageImg = async (path: string, file: File) => {
   };
 
 // storage 에 저장된 이미지를 다운로드 하는 함수
-export const getStorageImg = async (path: string): Promise<string | null> => {
-    const storageRef = ref(storage, path);
-  try {
-    return await getDownloadURL(storageRef);
-  } catch (error) {
-    console.error("다운로드 실패:", error);
-    return null;
-  }
+export const getStorageImg = async (path: string): Promise<string | void> => {
+  const storageRef = ref(storage, path);
+  return await getDownloadURL(storageRef).catch(error =>
+    console.log('다운로드 실패:', error)
+  );
 };
 
 // 생성된 문서에 다운로드 받은 이미지를 업데이트(수정, 추가) 하는 함수
 export const setProfileImg = async (getUserDocRef: DocumentReference, filePath: string): Promise<void> => {
-    const downloadURL = await getStorageImg(filePath)
-    if (downloadURL) {
-        await updateDoc(getUserDocRef, {
-            'user.profileUrl': downloadURL
-        })    
-    }
-    
-}
+    const downloadURL = await getStorageImg(filePath);
+    await updateDoc(getUserDocRef, {
+      'user.profileUrl': downloadURL
+    }).catch(error => console.log(error));
+  };

--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -30,8 +30,10 @@ export const getStorageImg = async (path: string): Promise<string | void> => {
 
 // 생성된 문서에 다운로드 받은 이미지를 업데이트(수정, 추가) 하는 함수
 export const setProfileImg = async (getUserDocRef: DocumentReference, filePath: string): Promise<void> => {
-    const downloadURL = await getStorageImg(filePath);
-    await updateDoc(getUserDocRef, {
-      'user.profileUrl': downloadURL
-    }).catch(error => console.log(error));
-  };
+    const downloadURL = await getStorageImg(filePath)
+    if (downloadURL) {
+        await updateDoc(getUserDocRef, {
+            'user.profileUrl': downloadURL
+        })    
+    }
+}

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -38,7 +38,7 @@ export const signOutAuth = async () => {
 };
 
 // 소셜 로그인후 uid 가져오는 함수
-const getUserId = async () => {
+export const getUserId = async () => {
   const userId: CachedData = await useGetCacheData('user', '/userId');
   return userId.cacheData;
 };

--- a/src/atoms/atoms.ts
+++ b/src/atoms/atoms.ts
@@ -132,6 +132,11 @@ export const searchResultsState = atom<SimplifyUser[]>({
 });
 
 export const imageState = atom({
-  key: 'imageState',
-  default: ''
+    key: 'imageState',
+    default: ''
+  })
+  
+export const userIdState = atom({
+  key: 'userIdState',
+  default: localStorage.getItem('userId') || null,
 });

--- a/src/components/common/FooterIcon.tsx
+++ b/src/components/common/FooterIcon.tsx
@@ -6,11 +6,13 @@ import { useNavigateTo } from '@/hooks/useNavigateTo';
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import { Column, Center } from '@/styles/layout';
 
+const userId = localStorage.getItem('userId');
+
 const routeMap = new Map();
 routeMap.set('home', '/');
 routeMap.set('feed', '/posts');
 routeMap.set('coffee', '/coffee');
-routeMap.set('my', '/profile');
+routeMap.set('my', `/profile/${userId}`);
 
 const FooterIcon = ({ icon }: { icon: string }) => {
   const [active, setActive] = useRecoilState(activeState);

--- a/src/components/common/FooterIcon.tsx
+++ b/src/components/common/FooterIcon.tsx
@@ -5,8 +5,9 @@ import Icon from '@/components/common/Icon';
 import { useNavigateTo } from '@/hooks/useNavigateTo';
 import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
 import { Column, Center } from '@/styles/layout';
+import useGetCacheData from '@/hooks/useGetCacheData';
 
-const userId = localStorage.getItem('userId');
+const userId = useGetCacheData('user', '/userId');
 
 const routeMap = new Map();
 routeMap.set('home', '/');

--- a/src/components/mypage/EditProfileImg.tsx
+++ b/src/components/mypage/EditProfileImg.tsx
@@ -1,0 +1,144 @@
+import '@pqina/pintura/pintura.css';
+import { useRef, useState } from 'react';
+import { useRecoilState } from 'recoil';
+import { imageState } from '@/atoms/atoms';
+import { PinturaEditorModal } from '@pqina/react-pintura';
+import { getEditorDefaults, createDefaultImageWriter } from '@pqina/pintura';
+import locale_ko_KR from '@pqina/pintura/locale/ko_KR';
+// _PINTURA IMPORTS
+import Icon from '@/components/common/Icon';
+import { EditProfileImgProps } from '@/types/types';
+import { iconPropsGenerator } from '@/utils/iconPropsGenerator';
+import { FlexCenter, Column } from '@/styles/layout';
+import { Cursor } from '@/styles/styles';
+import { styled } from 'styled-system/jsx';
+import { cx } from 'styled-system/css';
+
+const editorDefaults = getEditorDefaults({
+  cropImageSelectionCornerStyle: 'hook',
+  locale: {
+    ...locale_ko_KR
+  },
+  imageWriter: createDefaultImageWriter({
+    targetSize: {
+      width: 100,
+      height: 100,
+      fit: 'contain',
+      upscale: true
+    }
+  })
+});
+
+const EditProfileImg: React.FC<EditProfileImgProps> = ({ onImageSelect }) => {
+  const [editorEnabled, setEditorEnabled] = useState(false);
+  const [editorSrc, setEditorSrc] = useState<File>();
+  const [imageUrl, setImageUrl] = useRecoilState(imageState);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleInputChange = () => {
+    if (!fileInputRef?.current?.files?.length) return;
+    const file = fileInputRef?.current?.files[0];
+    if (fileInputRef?.current?.files) {
+      setEditorEnabled(true);
+      setEditorSrc(file);
+    }
+  };
+
+  const handleEditorHide = () => setEditorEnabled(false);
+
+  const handleEditorProcess = ({ dest }: { dest: File }) => {
+    const url = URL.createObjectURL(dest);
+    setImageUrl(url);
+    onImageSelect(dest);
+  };
+
+  return (
+    <>
+      <Wrapper className={cx(FlexCenter, Column)}>
+        <ImgContainer>
+          {imageUrl && (
+            <ImgRound>
+              <img
+                src={imageUrl}
+                alt="profile image"
+              />
+            </ImgRound>
+          )}
+          {!imageUrl && <Icon {...iconPropsGenerator('user', '100')} />}
+          <Edit className={Cursor}>
+            <label>
+              <Icon {...iconPropsGenerator('edit-photo', '32')} />
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                onChange={handleInputChange}
+                style={{ display: 'none' }}
+              />
+            </label>
+          </Edit>
+        </ImgContainer>
+      </Wrapper>
+
+      {editorEnabled && (
+        <PinturaEditorModal
+          {...editorDefaults}
+          src={editorSrc}
+          imageCropAspectRatio={1}
+          onHide={handleEditorHide}
+          onProcess={handleEditorProcess}
+          willRenderCanvas={(shapes, state) => {
+            const { utilVisibility, selectionRect, lineColor } = state;
+
+            if (utilVisibility.crop <= 0) return shapes;
+
+            const { x, y, width, height } = selectionRect;
+
+            return {
+              ...shapes,
+
+              interfaceShapes: [
+                {
+                  x: x + width * 0.5,
+                  y: y + height * 0.5,
+                  rx: width * 0.5,
+                  ry: height * 0.5,
+                  opacity: utilVisibility.crop,
+                  inverted: true,
+                  backgroundColor: [0, 0, 0, 0.1],
+                  strokeWidth: 0.4,
+                  strokeColor: [...lineColor]
+                },
+                ...shapes.interfaceShapes
+              ]
+            };
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+const Wrapper = styled.div`
+  padding: 20px 0 40px 0;
+`;
+const ImgContainer = styled.div`
+  position: relative;
+`;
+const ImgRound = styled.div`
+  width: 100px;
+  height: 100px;
+  border-radius: 100px;
+  overflow: hidden;
+`;
+const Edit = styled.div`
+  position: absolute;
+  width: 30px;
+  height: 30px;
+  bottom: 9px;
+  right: -2px;
+  z-index: 1;
+`;
+
+export default EditProfileImg;

--- a/src/components/mypage/MyProfile.tsx
+++ b/src/components/mypage/MyProfile.tsx
@@ -1,5 +1,7 @@
 import '@pqina/pintura/pintura.css';
 import { useEffect, useRef, useState } from 'react';
+import { useRecoilState } from 'recoil';
+import { imageState } from '@/atoms/atoms';
 import { PinturaEditorModal } from '@pqina/react-pintura';
 import { getEditorDefaults, createDefaultImageWriter } from '@pqina/pintura';
 import locale_ko_KR from '@pqina/pintura/locale/ko_KR';
@@ -46,7 +48,7 @@ const MyProfile = () => {
 
   const [editorEnabled, setEditorEnabled] = useState(false);
   const [editorSrc, setEditorSrc] = useState<File>();
-  const [imageUrl, setImageUrl] = useState<string>();
+  const [imageUrl, setImageUrl] = useRecoilState(imageState);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 

--- a/src/components/mypage/MyProfile.tsx
+++ b/src/components/mypage/MyProfile.tsx
@@ -1,22 +1,12 @@
-import { useEffect, useState } from 'react';
-import {
-  getStorageImg,
-  getUserDocRef,
-  setProfileImg,
-  setStorageImg
-} from '@/api/profile';
 import EditProfileImg from '@/components/mypage/EditProfileImg';
 import CheckNickname from '@/components/start/CheckNickname';
 import { TEXT } from '@/constants/texts';
 import { useComposeHeader } from '@/hooks/useComposeHeader';
+import { useImgSubmit } from '@/hooks/useImgSubmit';
 import { FlexCenter, Justify } from '@/styles/layout';
 import { Cursor, LineH18, TextGray, Border16, Medium } from '@/styles/styles';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
-import { CachedData } from '@/types/types';
-import useGetCacheData from '@/hooks/useGetCacheData';
-import { useRecoilState } from 'recoil';
-import { imageState } from '@/atoms/atoms';
 
 const MyProfile = () => {
   useComposeHeader(false, '프로필 수정', 'close');
@@ -25,41 +15,7 @@ const MyProfile = () => {
     console.log('회원 탈퇴');
   };
 
-  const [cachedData, setCachedData] = useState<CachedData>();
-
-  const getCachedUserInfo = async () => {
-    const data = await useGetCacheData('user', '/userId');
-    setCachedData(data);
-  };
-
-  const userId = cachedData?.cacheData;
-
-  useEffect(() => {
-    getCachedUserInfo();
-  }, []);
-
-  const [imageUrl, setImageUrl] = useRecoilState(imageState);
-
-  const handleFormSubmit = async () => {
-    if (userId && imageUrl) {
-      try {
-        const userDocRef = await getUserDocRef();
-        const filePath = `users/${userId}/profileImage.jpg`;
-
-        const response = await fetch(imageUrl);
-        const blob = await response.blob();
-
-        const file = new File([blob], 'profileImage.jpg', {
-          type: 'image/jpeg'
-        });
-        await setStorageImg(filePath, file);
-        await getStorageImg(filePath);
-        await setProfileImg(userDocRef, filePath);
-      } catch (err) {
-        console.log(err);
-      }
-    }
-  };
+  const { handleFormSubmit, setImageUrl } = useImgSubmit();
 
   const handleImageSelect = (selectedImage: File) => {
     setImageUrl(URL.createObjectURL(selectedImage));

--- a/src/components/mypage/MyProfile.tsx
+++ b/src/components/mypage/MyProfile.tsx
@@ -6,10 +6,12 @@ import { PinturaEditorModal } from '@pqina/react-pintura';
 import { getEditorDefaults, createDefaultImageWriter } from '@pqina/pintura';
 import locale_ko_KR from '@pqina/pintura/locale/ko_KR';
 // _PINTURA IMPORTS
-import { collection, doc, updateDoc } from 'firebase/firestore';
-import { getDownloadURL, ref } from 'firebase/storage';
-import { firestore, storage } from '@/firebase.config';
-import { useStorage } from '@/api/profile';
+import {
+  getStorageImg,
+  getUserDocRef,
+  setProfileImg,
+  setStorageImg
+} from '@/api/profile';
 import Icon from '@/components/common/Icon';
 import CheckNickname from '@/components/start/CheckNickname';
 import { TEXT } from '@/constants/texts';
@@ -39,8 +41,6 @@ const editorDefaults = getEditorDefaults({
 
 const MyProfile = () => {
   useComposeHeader(false, '프로필 수정', 'close');
-
-  const { uploadFile } = useStorage();
 
   const handleExitedUser = () => {
     console.log('회원 탈퇴');
@@ -86,27 +86,14 @@ const MyProfile = () => {
 
       if (fileInput?.files?.length) {
         const file = fileInput.files[0];
-
-        const collectionRef = collection(firestore, 'users');
-        const userDocRef = doc(collectionRef, userId);
-
-        // storage 에 저장하는 이미지
+        const userDocRef = await getUserDocRef();
         const filePath = `users/${userId}/profileImage.jpg`;
-        await uploadFile(filePath, file);
-
-        // 이미지가 저장되어있는 storage 를 참조하여
-        const storageRef = ref(storage, `users/${userId}/profileImage.jpg`);
-        // 해당 이미지를 다운로드
-        const downloadURL = await getDownloadURL(storageRef);
-
-        // 기존에 존재하는 collection 을 업데이트
-        await updateDoc(userDocRef, {
-          'user.profileUrl': downloadURL
-        });
+        await setStorageImg(filePath, file);
+        await getStorageImg(filePath);
+        await setProfileImg(userDocRef, filePath);
       }
     }
   };
-
   return (
     <>
       <Wrapper className={cx(FlexCenter, Column)}>

--- a/src/components/post/PostRegister.tsx
+++ b/src/components/post/PostRegister.tsx
@@ -1,7 +1,7 @@
 import '@pqina/pintura/pintura.css';
 import { useRef, useState } from 'react';
 import { PinturaEditorModal } from '@pqina/react-pintura';
-import { getEditorDefaults, createDefaultImageWriter } from '@pqina/pintura';
+import { getEditorDefaults } from '@pqina/pintura';
 import locale_ko_KR from '@pqina/pintura/locale/ko_KR';
 // _PINTURA
 import { useRecoilState, useRecoilValue } from 'recoil';
@@ -11,12 +11,7 @@ import CoffeeMenuSelection from '@/components/home/CoffeeMenuSelection';
 import RegisterLabel from '@/components/post/RegisterLabel';
 
 import { BUTTON_TEXTS, INPUT_TEXTS, LABEL_TEXTS } from '@/constants/common';
-import {
-  inputNicknameState,
-  registPostState,
-  useInputState
-} from '@/atoms/atoms';
-import { useStorage } from '@/api/profile';
+import { registPostState, useInputState } from '@/atoms/atoms';
 
 import { useShowFooter } from '@/hooks/useShowFooter';
 import { useNavigateTo } from '@/hooks/useNavigateTo';
@@ -45,7 +40,6 @@ const PostRegister = () => {
   const [editorSrc, setEditorSrc] = useState<File>();
   const [imageUrl, setImageUrl] = useState<string>();
 
-  const { uploadFile } = useStorage();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleInputChange = () => {

--- a/src/components/profile/ProfileImg.tsx
+++ b/src/components/profile/ProfileImg.tsx
@@ -6,18 +6,25 @@ import { Cursor } from '@/styles/styles';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
 
-const ProfileImg = ({ edit }: { edit: boolean }) => {
+const ProfileImg = ({ imageUrl }: { imageUrl?: string }) => {
   const handleProfile = useNavigateTo('/mypage');
 
   return (
     <Container className={cx(FlexCenter, MarginAuto)}>
       <Box className={cx(FlexCenter, MarginAuto)}>
         <div>
-          <Icon {...iconPropsGenerator('user', '100')} />
+          {imageUrl ? (
+            <ImgRound
+              src={imageUrl}
+              alt="Profile"
+            />
+          ) : (
+            <Icon {...iconPropsGenerator('user', '100')} />
+          )}
         </div>
         <Edit className={Cursor}>
           <Icon
-            {...iconPropsGenerator(!edit ? 'edit' : 'edit-photo', '32')}
+            {...iconPropsGenerator('edit', '32')}
             onTouchEnd={handleProfile}
           />
         </Edit>
@@ -33,8 +40,6 @@ const Container = styled.div`
 `;
 
 const Box = styled.div`
-  width: 54px;
-  height: 54px;
   position: relative;
 `;
 
@@ -42,9 +47,15 @@ const Edit = styled.div`
   position: absolute;
   width: 30px;
   height: 30px;
-  bottom: -15px;
-  right: -25px;
+  bottom: 9px;
+  right: -2px;
   z-index: 1;
+`;
+const ImgRound = styled.img`
+  width: 100px;
+  height: 100px;
+  border-radius: 100px;
+  overflow: hidden;
 `;
 
 export default ProfileImg;

--- a/src/components/start/InitialForm.tsx
+++ b/src/components/start/InitialForm.tsx
@@ -1,11 +1,12 @@
-import { useRecoilValue, useRecoilState } from 'recoil';
-import { authState, imageState } from '@/atoms/atoms';
+import { useRecoilValue } from 'recoil';
+import { authState } from '@/atoms/atoms';
 import Button from '@/components/common/Button';
 import EditProfileImg from '@/components/mypage/EditProfileImg';
 import SelectGender from '@/components/start/SelectGender';
 import CheckNickname from '@/components/start/CheckNickname';
 import { INITIAL_FORM_TEXTS } from '@/constants/start';
 import { BUTTON_TEXTS } from '@/constants/common';
+import { useImgSubmit } from '@/hooks/useImgSubmit';
 import { useNavigateTo } from '@/hooks/useNavigateTo';
 import { useComposeHeader } from '@/hooks/useComposeHeader';
 import { styled } from 'styled-system/jsx';
@@ -24,8 +25,7 @@ const { message } = INITIAL_FORM_TEXTS;
 const InitialForm = () => {
   useComposeHeader(false, '기본정보', 'close');
   const { user } = useRecoilValue(authState);
-  const [imageUrl, setImageUrl] = useRecoilState(imageState);
-
+  const { handleFormSubmit, setImageUrl } = useImgSubmit();
   const handleImageSelect = (selectedImage: File) => {
     setImageUrl(URL.createObjectURL(selectedImage));
   };

--- a/src/components/start/InitialForm.tsx
+++ b/src/components/start/InitialForm.tsx
@@ -1,13 +1,13 @@
+import { useRecoilValue, useRecoilState } from 'recoil';
+import { authState, imageState } from '@/atoms/atoms';
 import Button from '@/components/common/Button';
+import EditProfileImg from '@/components/mypage/EditProfileImg';
 import SelectGender from '@/components/start/SelectGender';
 import CheckNickname from '@/components/start/CheckNickname';
-import ProfileImg from '@/components/profile/ProfileImg';
-
 import { INITIAL_FORM_TEXTS } from '@/constants/start';
 import { BUTTON_TEXTS } from '@/constants/common';
 import { useNavigateTo } from '@/hooks/useNavigateTo';
 import { useComposeHeader } from '@/hooks/useComposeHeader';
-
 import { styled } from 'styled-system/jsx';
 import { Column } from '@/styles/layout';
 import {
@@ -17,8 +17,6 @@ import {
   Semibold,
   StartPageContainer
 } from '@/styles/styles';
-import { authState } from '@/atoms/atoms';
-import { useRecoilValue } from 'recoil';
 import { cx } from 'styled-system/css';
 
 const { message } = INITIAL_FORM_TEXTS;
@@ -26,6 +24,11 @@ const { message } = INITIAL_FORM_TEXTS;
 const InitialForm = () => {
   useComposeHeader(false, '기본정보', 'close');
   const { user } = useRecoilValue(authState);
+  const [imageUrl, setImageUrl] = useRecoilState(imageState);
+
+  const handleImageSelect = (selectedImage: File) => {
+    setImageUrl(URL.createObjectURL(selectedImage));
+  };
 
   return (
     <div className={Column}>
@@ -37,7 +40,7 @@ const InitialForm = () => {
           {message.second}
         </InitialFormText>
         <ProfileContainer>
-          <ProfileImg edit />
+          <EditProfileImg onImageSelect={handleImageSelect} />
         </ProfileContainer>
         <CheckNickname />
         <SelectGender />

--- a/src/components/start/SelectFavBrand.tsx
+++ b/src/components/start/SelectFavBrand.tsx
@@ -1,15 +1,14 @@
 import { useRecoilValue } from 'recoil';
 import { setInitialInfo } from '@/api/user';
+import { authState } from '@/atoms/atoms';
 import BrandItem from '@/components/start/BrandItem';
 import Button from '@/components/common/Button';
-
 import { SELECTFAVBRAND_TEXTS, BRANDLIST } from '@/constants/start';
 import { BUTTON_TEXTS } from '@/constants/common';
-import { useNavigateTo } from '@/hooks/useNavigateTo';
 import { useComposeHeader } from '@/hooks/useComposeHeader';
-import { authState } from '@/atoms/atoms';
+import { useImgSubmit } from '@/hooks/useImgSubmit';
+import { useNavigateTo } from '@/hooks/useNavigateTo';
 import { AuthTypes } from '@/types/types';
-
 import { styled } from 'styled-system/jsx';
 import { Grid } from '@/styles/layout';
 import { DefaultBtn, DisabledBtn, StartPageContainer } from '@/styles/styles';
@@ -20,6 +19,8 @@ const { message } = SELECTFAVBRAND_TEXTS;
 export const SelectFavBrand = () => {
   useComposeHeader(false, '기본정보', 'close');
   const { user } = useRecoilValue(authState);
+  const { handleFormSubmit, setImageUrl } = useImgSubmit();
+
   const navigateToHome = useNavigateTo('/');
   const navigateToMe = useNavigateTo('/start/3');
 
@@ -37,8 +38,9 @@ export const SelectFavBrand = () => {
       },
       signIn: true
     };
-
+    console.log(userInfo);
     setInitialInfo(userInfo);
+    handleFormSubmit();
     navigateToHome();
   };
 

--- a/src/firebase.config.ts
+++ b/src/firebase.config.ts
@@ -1,6 +1,5 @@
 import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
-import { getStorage } from "firebase/storage";
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -13,6 +12,5 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 const firestore = getFirestore(app);
-const storage = getStorage(app);
 
-export { app, firestore, storage };
+export { app, firestore };

--- a/src/hooks/useGetProfileImg.tsx
+++ b/src/hooks/useGetProfileImg.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { getDoc } from 'firebase/firestore';
+import useGetCacheData from '@/hooks/useGetCacheData';
+import { useRecoilState } from 'recoil';
+import { imageState } from '@/atoms/atoms';
+import { getUserDocRef } from '@/api/profile';
+
+export const useGetProfileImg = () => {
+  const [profileUrl, setProfileUrl] = useRecoilState(imageState);
+
+  const userId = useGetCacheData('user', '/userId');
+
+  useEffect(() => {
+    const fetchProfileImg = async () => {
+      if (!userId) {
+        return;
+      }
+      const userDocRef = await getUserDocRef();
+      try {
+        const fetchedImg = await getDoc(userDocRef);
+        if (fetchedImg.exists()) {
+          const userData = fetchedImg.data();
+          const userProfileUrl = userData?.user?.profileUrl || '';
+          setProfileUrl(userProfileUrl);
+        }
+      } catch (err) {
+        console.log(err);
+      }
+    };
+    fetchProfileImg();
+  }, [setProfileUrl]);
+};

--- a/src/hooks/useGetProfileImg.tsx
+++ b/src/hooks/useGetProfileImg.tsx
@@ -17,11 +17,11 @@ export const useGetProfileImg = () => {
       const userDocRef = await getUserDocRef();
       try {
         const fetchedImg = await getDoc(userDocRef);
-        if (fetchedImg.exists()) {
-          const userData = fetchedImg.data();
-          const userProfileUrl = userData?.user?.profileUrl || '';
-          setProfileUrl(userProfileUrl);
-        }
+        if (!fetchedImg.exists())
+          throw new Error('이미지가 존재하지 않습니다.');
+        const userData = fetchedImg.data();
+        const userProfileUrl = userData?.user?.profileUrl || '';
+        setProfileUrl(userProfileUrl);
       } catch (err) {
         console.log(err);
       }

--- a/src/hooks/useGetProfileImg.tsx
+++ b/src/hooks/useGetProfileImg.tsx
@@ -1,13 +1,12 @@
 import { useEffect } from 'react';
-import { getDoc } from 'firebase/firestore';
-import useGetCacheData from '@/hooks/useGetCacheData';
 import { useRecoilState } from 'recoil';
-import { imageState } from '@/atoms/atoms';
+import { getDoc } from 'firebase/firestore';
 import { getUserDocRef } from '@/api/profile';
+import { imageState } from '@/atoms/atoms';
+import useGetCacheData from '@/hooks/useGetCacheData';
 
 export const useGetProfileImg = () => {
   const [profileUrl, setProfileUrl] = useRecoilState(imageState);
-
   const userId = useGetCacheData('user', '/userId');
 
   useEffect(() => {

--- a/src/hooks/useImgSubmit.tsx
+++ b/src/hooks/useImgSubmit.tsx
@@ -1,0 +1,44 @@
+import { useState, useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import { imageState } from '@/atoms/atoms';
+import {
+  getUserDocRef,
+  setStorageImg,
+  getStorageImg,
+  setProfileImg
+} from '@/api/profile';
+import useGetCacheData from '@/hooks/useGetCacheData';
+import { CachedData } from '@/types/types';
+
+export const useImgSubmit = () => {
+  const [cachedData, setCachedData] = useState<CachedData>();
+  const [imageUrl, setImageUrl] = useRecoilState(imageState);
+  useEffect(() => {
+    const getCachedUserInfo = async () => {
+      const data = await useGetCacheData('user', '/userId');
+      setCachedData(data);
+    };
+    getCachedUserInfo();
+  }, []);
+
+  const handleFormSubmit = async () => {
+    if (!cachedData?.cacheData || !imageUrl) {
+      return;
+    }
+    const userDocRef = await getUserDocRef();
+    const filePath = `users/${cachedData.cacheData}/profileImage.jpg`;
+
+    const response = await fetch(imageUrl);
+    const blob = await response.blob();
+
+    const file = new File([blob], 'profileImage.jpg', {
+      type: 'image/jpeg'
+    });
+
+    await setStorageImg(filePath, file);
+    await getStorageImg(filePath);
+    await setProfileImg(userDocRef, filePath);
+  };
+
+  return { handleFormSubmit, setImageUrl };
+};

--- a/src/pages/Page-Profile.tsx
+++ b/src/pages/Page-Profile.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import FollowCount from '@/components/profile/FollowCount';
 import PostsGrid from '@/components/profile/PostsGrid';
 import ProfileDetail from '@/components/profile/ProfileDetail';
@@ -7,6 +8,10 @@ import { useComposeHeader } from '@/hooks/useComposeHeader';
 import { Between, Column } from '@/styles/layout';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
+import { collection, doc, getDoc, updateDoc } from 'firebase/firestore';
+import { firestore, storage } from '@/firebase.config';
+import { useRecoilState } from 'recoil';
+import { imageState } from '@/atoms/atoms';
 
 const Profile = () => {
   useComposeHeader(true, '', 'icons');
@@ -16,11 +21,41 @@ const Profile = () => {
     { number: FOLLOW.followed, label: '팔로워' }
   ];
 
+  const [profileUrl, setProfileUrl] = useRecoilState(imageState);
+
+  const userId = localStorage.getItem('userId');
+
+  const fetchUserProfile = async () => {
+    if (!userId) {
+      console.error('User ID is null or undefined');
+      return;
+    }
+    const userDocRef = doc(firestore, 'users', userId);
+    try {
+      const userDocSnapshot = await getDoc(userDocRef);
+
+      if (userDocSnapshot.exists()) {
+        const userData = userDocSnapshot.data();
+        const userProfileUrl = userData?.user?.profileUrl || ''; // Adjust the path according to your data structure
+
+        setProfileUrl(userProfileUrl);
+      } else {
+        console.error('User document not found');
+      }
+    } catch (error) {
+      console.error('Error fetching user profile:', error);
+    }
+  };
+
+  fetchUserProfile();
+
+  console.log('Profile URL:', profileUrl);
+
   return (
     <>
       <Container className={Column}>
         <div className={cx(Column, Between)}>
-          <ProfileImg edit={true} />
+          <ProfileImg imageUrl={profileUrl} />
           <ProfileDetail />
           <FollowCount icons={icons} />
         </div>

--- a/src/pages/Page-Profile.tsx
+++ b/src/pages/Page-Profile.tsx
@@ -11,13 +11,14 @@ import { Between, Column } from '@/styles/layout';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
 
+const icons = [
+  { number: FOLLOW.post, label: '게시물' },
+  { number: FOLLOW.following, label: '팔로잉' },
+  { number: FOLLOW.followed, label: '팔로워' }
+];
+
 const Profile = () => {
   useComposeHeader(true, '', 'icons');
-  const icons = [
-    { number: FOLLOW.post, label: '게시물' },
-    { number: FOLLOW.following, label: '팔로잉' },
-    { number: FOLLOW.followed, label: '팔로워' }
-  ];
 
   const [profileUrl, setProfileUrl] = useRecoilState(imageState);
 

--- a/src/pages/Page-Profile.tsx
+++ b/src/pages/Page-Profile.tsx
@@ -1,17 +1,16 @@
-import { useState } from 'react';
+import { useRecoilState } from 'recoil';
+import { doc, getDoc } from 'firebase/firestore';
+import { imageState } from '@/atoms/atoms';
 import FollowCount from '@/components/profile/FollowCount';
 import PostsGrid from '@/components/profile/PostsGrid';
 import ProfileDetail from '@/components/profile/ProfileDetail';
 import ProfileImg from '@/components/profile/ProfileImg';
 import { FOLLOW } from '@/constants/Follow';
 import { useComposeHeader } from '@/hooks/useComposeHeader';
+import { firestore } from '@/firebase.config';
 import { Between, Column } from '@/styles/layout';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
-import { collection, doc, getDoc, updateDoc } from 'firebase/firestore';
-import { firestore, storage } from '@/firebase.config';
-import { useRecoilState } from 'recoil';
-import { imageState } from '@/atoms/atoms';
 
 const Profile = () => {
   useComposeHeader(true, '', 'icons');
@@ -36,7 +35,7 @@ const Profile = () => {
 
       if (userDocSnapshot.exists()) {
         const userData = userDocSnapshot.data();
-        const userProfileUrl = userData?.user?.profileUrl || ''; // Adjust the path according to your data structure
+        const userProfileUrl = userData?.user?.profileUrl || '';
 
         setProfileUrl(userProfileUrl);
       } else {

--- a/src/pages/Page-Profile.tsx
+++ b/src/pages/Page-Profile.tsx
@@ -1,13 +1,12 @@
-import { useRecoilState } from 'recoil';
-import { doc, getDoc } from 'firebase/firestore';
 import { imageState } from '@/atoms/atoms';
+import { useRecoilState } from 'recoil';
 import FollowCount from '@/components/profile/FollowCount';
 import PostsGrid from '@/components/profile/PostsGrid';
 import ProfileDetail from '@/components/profile/ProfileDetail';
 import ProfileImg from '@/components/profile/ProfileImg';
 import { FOLLOW } from '@/constants/Follow';
 import { useComposeHeader } from '@/hooks/useComposeHeader';
-import { firestore } from '@/firebase.config';
+import { useGetProfileImg } from '@/hooks/useGetProfileImg';
 import { Between, Column } from '@/styles/layout';
 import { styled } from 'styled-system/jsx';
 import { cx } from 'styled-system/css';
@@ -22,33 +21,7 @@ const Profile = () => {
 
   const [profileUrl, setProfileUrl] = useRecoilState(imageState);
 
-  const userId = localStorage.getItem('userId');
-
-  const fetchUserProfile = async () => {
-    if (!userId) {
-      console.error('User ID is null or undefined');
-      return;
-    }
-    const userDocRef = doc(firestore, 'users', userId);
-    try {
-      const userDocSnapshot = await getDoc(userDocRef);
-
-      if (userDocSnapshot.exists()) {
-        const userData = userDocSnapshot.data();
-        const userProfileUrl = userData?.user?.profileUrl || '';
-
-        setProfileUrl(userProfileUrl);
-      } else {
-        console.error('User document not found');
-      }
-    } catch (error) {
-      console.error('Error fetching user profile:', error);
-    }
-  };
-
-  fetchUserProfile();
-
-  console.log('Profile URL:', profileUrl);
+  useGetProfileImg();
 
   return (
     <>

--- a/src/pages/Router.tsx
+++ b/src/pages/Router.tsx
@@ -12,7 +12,8 @@ const LazyRoutes = ROUTES.map(route => {
   const routeConfig: { [key: string]: LazyRouteType } = {
     Home: { index: true, path: '' },
     Start: { index: false, path: 'start/:id' },
-    Post: { index: false, path: 'post/:postid' }
+    Post: { index: false, path: 'post/:postid' },
+    Profile: { index: false, path: 'profile/:userId' }
   };
 
   const { index, path } = routeConfig[route] || {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -116,3 +116,7 @@ export interface caffeineFilterTypes {
 export enum Collections {
   USERS = 'users'
 }
+
+export interface EditProfileImgProps {
+  onImageSelect: (setProfileImg: File) => void
+}


### PR DESCRIPTION
<!-- PR name > Prefix: 기능 분할 단위  ex) Feat: search 기능 구현 -->

## ☕ PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [x] 코드 업데이트
- [x] 사소한 수정

## ☕ 작업 내용

<!--작업 내용을 간단하게 기록 후 구현 img or gif 첨부-->

- `MyPage` 에서 `ProfileImg` 등록 👉  `Profile Page` 에서 확인 가능
- `EditProfileImg` 컴포넌트를 분리하여 `InitialForm` 과 `MyProfile` 에서 재사용
- `useGetProfileImg` 훅 생성

<img width="300" alt="image" src="https://github.com/7-7-2/DDocker/assets/96659041/0efcfb84-d2bf-4261-93af-0b83ac1fe71c">
<img width="300" alt="image" src="https://github.com/7-7-2/DDocker/assets/96659041/850c4fca-6264-4ce9-9eba-49a216f51726">

### ✔ 리뷰 수정 사항 반영 및 이슈 해결

- 리뷰 수정 사항 반영
- 이슈 사항 해결
- 재사용 컴포넌트를 위한 커스텀 훅 분리
- `InitialForm` 컴포넌트 👉 프로필 등록 기능 추가

<img width="300" alt="image" src="https://github.com/7-7-2/DDocker/assets/96659041/a62c9aa6-f1d3-45ac-b256-8faae9720ce2">


## ☕ 관련 issue

현재 `InitialForm` 컴포넌트 (`/start/2`) 에서는 ProfileImg 등록 기능을 추가하지 않아 아래 이슈가 발생합니다 
<h3>👉 바로 추가 하겠습니다 !</h3>

1️⃣ `InitialForm` 에서 이미지 등록
2️⃣  `/` 로 이동 시 `start/2` 에서 등록한 `username` 반영 ❌
3️⃣  `Profile Page` 에서 이미지 확인 ❌
4️⃣  DB 에 `profileUrl` 업데이트 ❌

<img width="300" alt="image" src="https://github.com/7-7-2/DDocker/assets/96659041/3bd3c719-c5e9-43c2-925e-7977c81c4862">
<img width="300" alt="image" src="https://github.com/7-7-2/DDocker/assets/96659041/06fcb020-8945-4b87-a9a9-6a0aca425ef9">
<img width="300" alt="image" src="https://github.com/7-7-2/DDocker/assets/96659041/2a7e05b7-de1f-40ff-b95a-ad7a1b36c9e7">
<img width="300" alt="image" src="https://github.com/7-7-2/DDocker/assets/96659041/47835adb-9664-4f97-98a8-426e46a5fafc">

<br>

### ❗ 새로운 이슈사항

- 초기 `start/1`, `start/2`, `start/3` 경로를 거친 뒤 `/` 경로로 이동 시
이전 Cache Storage 의 정보가 남아있어 회원 가입 시 등록한 유저 닉네임이 새로고침을 해야 반영됩니다.

<img width="300" alt="image" src="https://github.com/7-7-2/DDocker/assets/96659041/a62c9aa6-f1d3-45ac-b256-8faae9720ce2">

- closed #69 #82 